### PR TITLE
Create Terraform module for OCI VCN and Subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # terraform_vcn
+
+# OCI VCN and Subnet Terraform Configuration
+
+This Terraform module creates a new compartment, a Virtual Cloud Network (VCN), and a specified number of subnets within that VCN in Oracle Cloud Infrastructure (OCI).
+
+## Prerequisites
+
+1.  **OCI Account**: You must have an active OCI account.
+2.  **OCI CLI Configured**: Your OCI Command Line Interface (CLI) must be configured with the necessary credentials and default region. Terraform will use this configuration for authentication and to determine the region if not explicitly set. You can test your configuration by running `oci iam region list`.
+3.  **Terraform Installed**: Terraform (version 1.x or later recommended) must be installed on your local machine.
+
+## Configuration Variables
+
+The following variables need to be configured, typically in a `terraform.tfvars` file or by providing them at the command line:
+
+| Variable             | Description                                                                 | Type          | Default Value          | Example                                       |
+| -------------------- | --------------------------------------------------------------------------- | ------------- | ---------------------- | --------------------------------------------- |
+| `region`             | The OCI region where resources will be created.                             | `string`      | (none - must be set)   | `"us-ashburn-1"`                              |
+| `compartment_name`   | The name for the new compartment where the VCN and subnets will be created. | `string`      | `"NetworkingCompartment"`| `"MyProdNetworking"`                          |
+| `vcn_cidr_block`     | The CIDR block for the VCN.                                                 | `string`      | (none - must be set)   | `"10.0.0.0/16"`                               |
+| `subnet_cidr_blocks` | A list of CIDR blocks for the subnets.                                      | `list(string)`| (none - must be set)   | `["10.0.1.0/24", "10.0.2.0/24"]`              |
+
+## Usage
+
+1.  **Clone the repository (if applicable) or ensure you have the `.tf` files.**
+
+2.  **Create a `terraform.tfvars` file** in the same directory with your desired variable values. For example:
+
+    ```terraform
+    region             = "us-phoenix-1"
+    compartment_name   = "MyVCNCompartment"
+    vcn_cidr_block     = "192.168.0.0/16"
+    subnet_cidr_blocks = ["192.168.1.0/24", "192.168.2.0/24", "192.168.3.0/24"]
+    ```
+
+3.  **Initialize Terraform**:
+    ```bash
+    terraform init
+    ```
+
+4.  **Plan the deployment**:
+    ```bash
+    terraform plan
+    ```
+    Review the plan to ensure it matches your expectations.
+
+5.  **Apply the configuration**:
+    ```bash
+    terraform apply
+    ```
+    Type `yes` when prompted to confirm.
+
+## Outputs
+
+After a successful apply, Terraform will output the following:
+
+| Output Name          | Description                                      |
+| -------------------- | ------------------------------------------------ |
+| `vcn_compartment_id` | The OCID of the compartment created for the VCN. |
+| `vcn_id`             | The OCID of the created VCN.                     |
+| `vcn_dns_label`      | The DNS label of the created VCN.                |
+| `subnet_ids`         | A list of OCIDs of the created subnets.          |
+| `subnet_dns_labels`  | The DNS labels of the created subnets.           |

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,48 @@
+# Data source to get the OCID of the current tenancy
+data "oci_identity_tenancy" "current_tenancy" {}
+
+# Resource to create a new compartment for the VCN and related resources
+resource "oci_identity_compartment" "vcn_compartment" {
+  name           = var.compartment_name
+  description    = "Compartment for the VCN and related networking resources"
+  compartment_id = data.oci_identity_tenancy.current_tenancy.id # Creates the compartment in the root/tenancy
+  enable_delete  = true # Set to true to allow deletion of the compartment via Terraform
+}
+
+# Resource to create the Virtual Cloud Network (VCN)
+resource "oci_core_vcn" "custom_vcn" {
+  cidr_block     = var.vcn_cidr_block
+  compartment_id = oci_identity_compartment.vcn_compartment.id
+  display_name   = "CustomVCN"
+
+  dns_label      = "customvcn" # DNS label for the VCN, must be unique within the subnet
+
+  # Freeform tags are optional
+  # freeform_tags = {
+  #   "Environment" = "Development"
+  # }
+}
+
+# Resource to create subnets within the VCN
+resource "oci_core_subnet" "custom_subnets" {
+  count          = length(var.subnet_cidr_blocks)
+  vcn_id         = oci_core_vcn.custom_vcn.id
+  compartment_id = oci_identity_compartment.vcn_compartment.id
+  cidr_block     = var.subnet_cidr_blocks[count.index]
+  display_name   = "Subnet-${count.index + 1}"
+
+  # DNS label for each subnet, must be unique within the VCN
+  # Ensure the label is valid (no dots, max 15 chars, starts with letter)
+  dns_label      = "subnet${count.index + 1}"
+
+  # Optional: Specify a security list OCID if you have one pre-defined
+  # security_list_ids = [oci_core_vcn.custom_vcn.default_security_list_id]
+
+  # Optional: Specify a route table OCID if you have one pre-defined
+  # route_table_id = oci_core_vcn.custom_vcn.default_route_table_id
+
+  # Freeform tags are optional
+  # freeform_tags = {
+  #   "Name" = "Subnet-${count.index + 1}"
+  # }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,29 @@
+output "vcn_id" {
+  description = "The OCID of the created VCN."
+  value       = oci_core_vcn.custom_vcn.id
+}
+
+output "vcn_compartment_id" {
+  description = "The OCID of the compartment created for the VCN."
+  value       = oci_identity_compartment.vcn_compartment.id
+}
+
+output "subnet_ids" {
+  description = "A list of OCIDs of the created subnets."
+  value       = [for s in oci_core_subnet.custom_subnets : s.id]
+  # For older Terraform versions that don't support the for expression in outputs directly,
+  # you might need to use `oci_core_subnet.custom_subnets.*.id`
+  # value       = oci_core_subnet.custom_subnets.*.id 
+}
+
+output "vcn_dns_label" {
+  description = "The DNS label of the created VCN."
+  value       = oci_core_vcn.custom_vcn.dns_label
+}
+
+output "subnet_dns_labels" {
+  description = "The DNS labels of the created subnets."
+  value       = [for s in oci_core_subnet.custom_subnets : s.dns_label]
+  # For older Terraform versions:
+  # value       = oci_core_subnet.custom_subnets.*.dns_label
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0.0" # Using a recent version, adjust if necessary
+    }
+  }
+}
+
+provider "oci" {
+  # The region is sourced from the 'region' variable defined in variables.tf
+  # Ensure your OCI CLI configuration is set up correctly for authentication,
+  # or configure authentication details directly in this block if needed.
+  # Example:
+  # tenancy_ocid     = var.tenancy_ocid
+  # user_ocid        = var.user_ocid
+  # fingerprint      = var.fingerprint
+  # private_key_path = var.private_key_path
+  region = var.region
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,21 @@
+variable "vcn_cidr_block" {
+  type        = string
+  description = "The CIDR block for the VCN. Example: \"10.0.0.0/16\""
+}
+
+variable "subnet_cidr_blocks" {
+  type        = list(string)
+  description = "A list of CIDR blocks for the subnets. Example: [\"10.0.1.0/24\", \"10.0.2.0/24\"]"
+}
+
+variable "compartment_name" {
+  type        = string
+  description = "The name for the new compartment where the VCN and subnets will be created."
+  default     = "NetworkingCompartment"
+}
+
+variable "region" {
+  type        = string
+  description = "The OCI region where resources will be created. Example: \"us-ashburn-1\""
+  # No default, as this should be explicitly set or come from OCI config.
+}


### PR DESCRIPTION
This commit introduces a Terraform configuration to provision Oracle Cloud Infrastructure resources:

- A new compartment to house networking resources.
- A Virtual Cloud Network (VCN) with a user-defined CIDR block.
- A user-defined number of subnets, each with its own CIDR block.

Key features:
- **Dynamic Configuration**: VCN CIDR, subnet CIDRs, compartment name, and region are configurable via variables.
- **Modularity**: Separates variables, main logic, outputs, and provider configuration into distinct files.
- **Documentation**: Includes a README with setup instructions, variable explanations, and usage examples.

The module allows you to quickly set up a foundational network structure in OCI.